### PR TITLE
Backup Spotify Albums too

### DIFF
--- a/src/Backupper.php
+++ b/src/Backupper.php
@@ -4,6 +4,7 @@ namespace HansOtt\SpotifyBackupper;
 
 use HansOtt\SpotifyBackupper\Client\Client;
 use HansOtt\SpotifyBackupper\Spotify\Track;
+use HansOtt\SpotifyBackupper\Spotify\Album;
 use HansOtt\SpotifyBackupper\Encoder\Encoder;
 use HansOtt\SpotifyBackupper\BackupStorage\BackupStorage;
 
@@ -83,6 +84,28 @@ final class Backupper
         $filePath = sprintf('saved-tracks-%s.%s', date('Y-m-d'), $this->encoder->getFileExtension());
         $this->backupStorage->writeFile($filePath, $data);
         echo sprintf('Created backup of saved tracks.') . PHP_EOL;
+
+        echo 'Getting saved albums...' . PHP_EOL;
+
+        $limit = 50;
+        $offset = 0;
+        $allAlbums = [];
+
+        do {
+            $albums = $this->client->getSavedAlbums($limit, $offset);
+            $allAlbums = array_merge($allAlbums, $albums);
+            $fetched = count($albums);
+            $offset += $limit;
+        } while ($fetched === $limit);
+
+        $data = array_map(function (Album $album) {
+            return $album->toArray();
+        }, $allAlbums);
+
+        $data = $this->encoder->encode($data);
+        $filePath = sprintf('saved-albums-%s.%s', date('Y-m-d'), $this->encoder->getFileExtension());
+        $this->backupStorage->writeFile($filePath, $data);
+        echo sprintf('Created backup of saved albums.') . PHP_EOL;
 
         echo 'Finished' . PHP_EOL;
     }

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -38,4 +38,14 @@ interface Client
      * @return Track[]
      */
     public function getSavedTracks($limit = 20, $offset = 0);
+
+    /**
+     * Get the user's saved albums.
+     *
+     * @param int $limit
+     * @param int $offset
+     *
+     * @return Album[]
+     */
+    public function getSavedAlbums($limit = 20, $offset = 0);
 }

--- a/src/Client/ClientBuzz.php
+++ b/src/Client/ClientBuzz.php
@@ -10,6 +10,7 @@ use Buzz\Client\ClientInterface;
 use HansOtt\SpotifyBackupper\Spotify\Track;
 use HansOtt\SpotifyBackupper\Spotify\Artist;
 use HansOtt\SpotifyBackupper\Spotify\Playlist;
+use HansOtt\SpotifyBackupper\Spotify\Album;
 
 final class ClientBuzz implements Client
 {
@@ -115,5 +116,33 @@ final class ClientBuzz implements Client
         );
 
         return $this->convertResponseToTracks($data);
+    }
+
+    public function getSavedAlbums($limit = 20, $offset = 0)
+    {
+        $data = $this->performRequest(
+            '/v1/me/albums',
+            array(
+                'limit' => (int) $limit,
+                'offset' => (int) $offset,
+            )
+        );
+
+        return $this->convertResponseToAlbums($data);
+    }
+
+    private function convertResponseToAlbums($data)
+    {
+        $albums = isset($data['items']) && is_array($data['items']) ? $data['items'] : array();
+
+        return array_map(function (array $album) {
+            $album = $album['album'];
+
+            $artists = array_map(function (array $artist) {
+                return new Artist($artist['id'], $artist['name'], $artist['uri']);
+            }, $album['artists']);
+
+            return new Album($album['id'], $album['name'], $album['uri'], $artists);
+        }, $albums);
     }
 }

--- a/src/Spotify/Album.php
+++ b/src/Spotify/Album.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace HansOtt\SpotifyBackupper\Spotify;
+
+use HansOtt\SpotifyBackupper\CastsToArray;
+
+final class Album implements CastsToArray
+{
+    private $id;
+
+    private $name;
+
+    private $uri;
+
+    private $artists;
+
+    /**
+     * Track constructor.
+     *
+     * @param string $id
+     * @param string $name
+     * @param string $uri
+     * @param Artist[] $artists
+     */
+    public function __construct($id, $name, $uri, array $artists)
+    {
+        $this->id = (string) $id;
+        $this->name = (string) $name;
+        $this->uri = (string) $uri;
+        $this->artists = $artists;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    public function getArtists()
+    {
+        return $this->artists;
+    }
+
+    public function toArray()
+    {
+        return array(
+            'id' => $this->id,
+            'name' => $this->name,
+            'uri' => $this->uri,
+            'artists' => array_map(function (Artist $artist) {
+                return $artist->toArray();
+            }, $this->getArtists()),
+        );
+    }
+}


### PR DESCRIPTION
Completely duplicated behaviour to backup Tracks, so that we can also
backup Albums. We might want to do some abstacting in the Backupper
class now...
- Created an `Album` class
- Added flow to Backupper
- Added appropriate methods to Client
- Backup to `saved-albums-{date}.json`
